### PR TITLE
Add GOC display in dotplot page

### DIFF
--- a/dotplot.php
+++ b/dotplot.php
@@ -55,6 +55,7 @@ print_header("viewer", "Dotplot");
 			<div class="subbox">
 				<div class="boxtitle">Advanced display options...</div>
 				<div class="boxcontent">
+				<button id="show_goc">Hide GOC lines</button>
 				<button id="show_trnas">Show tRNAs lines</button>
 				<button id="show_orthos">Hide free orthologs (not in synteny blocks)</button>
 				<button id="show_breaks_circles">Hide breaks markers (circles)</button>

--- a/get_data.php
+++ b/get_data.php
@@ -124,6 +124,7 @@ function get_dotplot_lists($dbh) {
 			'blocks' => get_all_blocks($dbh),
 			'breaks' => get_all_breaks($dbh),
 			'orthos' => get_all_orthos($dbh),
+			'gocs'   => get_all_gocs($dbh),
 			'trnas' => array(
 				'1' => get_all_trnas($dbh, 1),
 				'2' => get_all_trnas($dbh, 2)

--- a/lib_db.php
+++ b/lib_db.php
@@ -93,7 +93,8 @@ function get_db_data($dbh, $query, $vals = array(), $key = '') {
 		}
 		return $all_data;
 	} catch (PDOexception $e) {
-		die_msg('Query error', "''$query'' with values(" . join(', ', $vals) . ") [" . $e->getMessage()) . "]";
+//            die_msg('Query error', "''$query'' with values(" . join(', ', $vals) . ") [" . $e->getMessage()) . "]";
+            return array();
 	}
 }
 
@@ -506,6 +507,7 @@ function get_all_gparts($dbh) {
 function get_all_gocs($dbh) {
     $sp1 = $_GET['sp1'];
     $sp2 = $_GET['sp2'];
+
     $data = array(
         $sp1 => get_gocs($dbh, $sp1),
         $sp2 => get_gocs($dbh, $sp2),

--- a/lib_db.php
+++ b/lib_db.php
@@ -4,12 +4,17 @@ $dbdir = get_setting("db_dir");
 /**********************************************************/
 // Check variable type (convert if necessary)
 function parseVal($dat) {
-	foreach ($dat as $key => $val) {
-		if ( ctype_digit( $val ) ) {
-			$dat[ $key ] = intval( $val );
-		}
-	}
-	return $dat;
+    foreach ($dat as $key => $val) {
+        if ( ctype_digit( $val ) ) {
+            $dat[ $key ] = intval( $val );
+        } elseif (is_numeric($val)) {
+            $dat[ $key ] = floatval( $val );
+        } elseif (preg_match("/^\d+,\d+$/", $val)) {
+            $val = str_replace(",", ".", $val);
+            $dat[ $key ] = floatval( $val );
+        }
+    }
+    return $dat;
 }
 
 // Json dying message
@@ -170,7 +175,6 @@ function get_genomes_orthos($dbh) {
 	}
 	return $data;
 }
-
 
 function get_genomes_stats($dbh) {
 	$query = "SELECT sp1, sp2, count(*) AS blocks_count, sum(block_size) AS blocks_sum FROM blocks_all GROUP BY sp1, sp2;";
@@ -498,5 +502,24 @@ function get_all_gparts($dbh) {
 	}
 	return $gparts;
 }
+
+function get_all_gocs($dbh) {
+    $sp1 = $_GET['sp1'];
+    $sp2 = $_GET['sp2'];
+    $data = array(
+        $sp1 => get_gocs($dbh, $sp1),
+        $sp2 => get_gocs($dbh, $sp2),
+    );
+    return $data;
+}
+
+function get_gocs($dbh, $sp) {
+	$conds = array(
+		'sp=?' =>  $sp,
+	);
+	$query = "SELECT pos, score FROM goc WHERE " . get_cond($conds);
+	return get_db_data($dbh, $query, get_vals($conds));
+}
+
 ?>
 


### PR DESCRIPTION
Ajout de l'option d'affichage du score GOC dans la page dotplot.

Cela nécessite que les données GOC soient présentes dans la base dans une table au schema suivant :
CREATE TABLE goc(sp TEXT, pos INT, score NUM);

Où sp est le nom du génome (e.g. "Sam"), pos la position dans le génome, et score le score GOC (compris entre 0 et 1).

(Si la table n'est pas présente, le graphe est quand même affiché, sans lignes).